### PR TITLE
Sync skills/integrate-agentforce-android from internal

### DIFF
--- a/skills/integrate-agentforce-android/SKILL.md
+++ b/skills/integrate-agentforce-android/SKILL.md
@@ -122,7 +122,8 @@ dependencyResolutionManagement {
 ```kotlin
 plugins {
     id("com.android.application")
-    id("kotlin-android")
+    id("org.jetbrains.kotlin.android")
+    id("org.jetbrains.kotlin.plugin.compose")
     id("kotlin-kapt")
     id("kotlinx-serialization")
 }
@@ -142,11 +143,17 @@ dependencies {
 }
 ```
 
+On Kotlin 2.0+, `composeOptions.kotlinCompilerExtensionVersion` is replaced
+by the `org.jetbrains.kotlin.plugin.compose` Gradle plugin. Apply that
+plugin (matched to the project's Kotlin version) and remove any leftover
+`composeOptions { ... }` block from the consuming module — AGP errors when
+both are present.
+
 The consumer needs:
 
 - **Min SDK ≥ 29** (Android 10).
 - **Compose enabled** in their app module — the chat UI is `@Composable`.
-- **Kotlin ≥ 1.9.22**, AGP **8.9.1+**, **Android Studio Meerkat 2024.3.1+**.
+- **Kotlin ≥ 2.1** (recommend 2.2.0), AGP **8.9.1+**, **Android Studio Meerkat 2024.3.1+**. `agentforce-sdk:15.0.2` is published with Kotlin metadata 2.1.0/2.2.0; consumers on Kotlin 1.9.x fail kapt with a metadata-version mismatch.
 
 If their app is not Compose-based, surface this and ask whether they want to add Compose to the existing module. The SDK does not ship a View-based chat surface.
 

--- a/skills/integrate-agentforce-android/references/dep-detection.md
+++ b/skills/integrate-agentforce-android/references/dep-detection.md
@@ -50,10 +50,16 @@ dependencyResolutionManagement {
 
 ## App-module `build.gradle.kts`
 
+On Kotlin 2.0+, the legacy `composeOptions.kotlinCompilerExtensionVersion`
+setting is obsolete — the new compiler model is shipped as a dedicated
+Gradle plugin (`org.jetbrains.kotlin.plugin.compose`) that replaces it.
+Apply that plugin instead; AGP errors out if `composeOptions` is also set.
+
 ```kotlin
 plugins {
     id("com.android.application")
-    id("kotlin-android")
+    id("org.jetbrains.kotlin.android")
+    id("org.jetbrains.kotlin.plugin.compose")
     id("kotlin-kapt")
     id("kotlinx-serialization")
 }
@@ -75,9 +81,6 @@ android {
     buildFeatures {
         compose = true
     }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.11"
-    }
 }
 
 dependencies {
@@ -89,6 +92,11 @@ dependencies {
 }
 ```
 
+Make sure the root `build.gradle.kts` pins `kotlin-gradle-plugin`,
+`kotlin-serialization`, and `compose-compiler-gradle-plugin` to the same
+Kotlin version (see floors below) so kapt doesn't blow up with a metadata
+mismatch.
+
 ## Compose enablement check
 
 The Agentforce SDK's UI is `@Composable`. If the consumer's app module does not have `buildFeatures.compose = true`, the chat container won't render. Surface this and ask whether to add Compose to the existing module before scaffolding `AgentforceChatHost.kt`.
@@ -96,7 +104,7 @@ The Agentforce SDK's UI is `@Composable`. If the consumer's app module does not 
 ## Min SDK / Kotlin / AGP requirements
 
 - **Min SDK:** 29 (Android 10).
-- **Kotlin:** 1.9.22 or higher.
+- **Kotlin:** **2.1 or higher** (recommend 2.2.0). `agentforce-sdk:15.0.2` is published with Kotlin metadata version 2.1.0/2.2.0; consumers on Kotlin 1.9.x fail kapt with `Module was compiled with an incompatible version of Kotlin. The binary version of its metadata is 2.1.0/2.2.0, expected version is 1.9.0`. Bump `kotlin-gradle-plugin`, `kotlin-serialization`, and `compose-compiler-gradle-plugin` together.
 - **Android Gradle Plugin:** 8.9.1+ (mostly for desugar_jdk_libs:2.1.5 support).
 - **Android Studio:** Meerkat 2024.3.1 or newer.
 

--- a/skills/integrate-agentforce-android/references/snippets/AppAgentforceUIDelegate.kt
+++ b/skills/integrate-agentforce-android/references/snippets/AppAgentforceUIDelegate.kt
@@ -7,7 +7,6 @@ import android.util.Log
 import com.salesforce.android.agentforcesdkimpl.AgentConversation
 import com.salesforce.android.agentforcesdkimpl.AgentforceUIDelegate
 import com.salesforce.android.agentforceservice.AgentforceUtterance
-import com.salesforce.android.agentforceservice.conversationservice.data.AgentforceMessage
 
 class AppAgentforceUIDelegate : AgentforceUIDelegate {
 
@@ -25,12 +24,5 @@ class AppAgentforceUIDelegate : AgentforceUIDelegate {
 
     override fun userDidSwitchAgents(newConversation: AgentConversation) {
         // TODO: react to multi-agent handoff (e.g. update header, log event).
-    }
-
-    override fun didReceiveResponse(
-        agentforceMessage: AgentforceMessage,
-        conversation: AgentConversation
-    ) {
-        // TODO: react to incoming agent messages if you need server-side analytics.
     }
 }

--- a/skills/integrate-agentforce-android/references/snippets/AppNavigation.kt
+++ b/skills/integrate-agentforce-android/references/snippets/AppNavigation.kt
@@ -1,16 +1,22 @@
 // No-op Navigation implementation. Replace with real navigation logic
 // when you want the agent to open records or app screens — e.g. parse
-// the URL and dispatch to your Navigation Compose graph or Activity.
+// the destination URL and dispatch to your Navigation Compose graph.
 
 package {{PACKAGE}}.agentforce
 
 import com.salesforce.android.mobile.interfaces.navigation.Navigation
+import com.salesforce.android.mobile.interfaces.navigation.destination.App
+import com.salesforce.android.mobile.interfaces.navigation.destination.Destination
 
 class AppNavigation : Navigation {
 
-    override fun navigate(url: String) {
+    override fun goto(destination: Destination) {
         // TODO: handle navigation requests from the agent.
-        // Example: parse the URL and dispatch to your nav graph,
-        // or fall through to a Custom Tabs intent.
     }
+
+    override fun goto(destination: Destination, replace: Boolean) {
+        // TODO: handle navigation requests from the agent (with replace semantics).
+    }
+
+    override fun openApp(app: App): App.OpenResult = App.OpenResult.NOTOPEN
 }

--- a/skills/integrate-agentforce-android/references/snippets/AppNetwork.kt
+++ b/skills/integrate-agentforce-android/references/snippets/AppNetwork.kt
@@ -24,21 +24,20 @@ class AppNetwork(
         withContext(Dispatchers.IO) {
             val httpRequest = Request.Builder().apply {
                 url(request.path)
-                request.headers.forEach { (key, value) -> addHeader(key, value) }
+                request.additionalHttpHeaders.forEach { entry ->
+                    addHeader(entry.key, entry.value)
+                }
+
+                val mediaType = request.contentType?.toMediaType()
+                    ?: "application/json".toMediaType()
 
                 when (request.method) {
                     NetworkRequest.Method.GET -> get()
                     NetworkRequest.Method.DELETE -> delete()
-                    NetworkRequest.Method.POST -> {
-                        val mediaType = request.contentType?.toMediaType()
-                            ?: "application/json".toMediaType()
-                        post(request.body?.toRequestBody(mediaType))
-                    }
-                    NetworkRequest.Method.PUT -> {
-                        val mediaType = request.contentType?.toMediaType()
-                            ?: "application/json".toMediaType()
-                        put(request.body?.toRequestBody(mediaType))
-                    }
+                    NetworkRequest.Method.POST ->
+                        post((request.body ?: ByteArray(0)).toRequestBody(mediaType))
+                    NetworkRequest.Method.PUT ->
+                        put((request.body ?: ByteArray(0)).toRequestBody(mediaType))
                     else -> throw IllegalArgumentException(
                         "Unsupported HTTP method: ${request.method}"
                     )
@@ -47,13 +46,11 @@ class AppNetwork(
 
             okHttpClient.newCall(httpRequest).execute().use { response ->
                 NetworkResponse(
-                    body = response.body?.string()?.toByteArray(),
+                    request = request,
                     statusCode = response.code,
-                    headers = response.headers.toMap()
+                    headers = response.headers.toMultimap(),
+                    body = response.body?.string()?.toByteArray()
                 )
             }
         }
-
-    private fun okhttp3.Headers.toMap(): Map<String, String> =
-        names().associateWith { name -> get(name).orEmpty() }
 }


### PR DESCRIPTION
Automated sync of `skills/integrate-agentforce-android` 

## Changes
- **SKILL.md** / **references/dep-detection.md** — bump Kotlin floor `1.9.22` → **2.1+ (recommend 2.2.0)**; switch `kotlin-android` → `org.jetbrains.kotlin.android` and add `org.jetbrains.kotlin.plugin.compose`; remove the obsolete `composeOptions.kotlinCompilerExtensionVersion` block; document the `agentforce-sdk:15.0.2` Kotlin-metadata-mismatch failure on 1.9.x.
- **references/snippets/AppAgentforceUIDelegate.kt** — remove the now-removed `didReceiveResponse(...)` override and its import.
- **references/snippets/AppNavigation.kt** — migrate the `Navigation` impl from `navigate(url)` to the new `goto(destination)` / `goto(destination, replace)` / `openApp(app)` API.
- **references/snippets/AppNetwork.kt** — update to the new `NetworkRequest`/`NetworkResponse` shape (`additionalHttpHeaders`, `request=` on the response, `toMultimap()`, non-null body handling).